### PR TITLE
session completely refreshed when using KeyCloak 

### DIFF
--- a/app/config/commons/all/config.yml
+++ b/app/config/commons/all/config.yml
@@ -17,7 +17,7 @@ framework:
     trusted_proxies: ~
     session:
         handler_id: session.handler.pdo
-        gc_maxlifetime: 900
+        gc_maxlifetime: 3600
     fragments:       ~
     http_method_override: true
     profiler: { only_exceptions: true }

--- a/src/Mealz/UserBundle/Entity/Profile.php
+++ b/src/Mealz/UserBundle/Entity/Profile.php
@@ -2,6 +2,7 @@
 
 namespace Mealz\UserBundle\Entity;
 
+use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -15,7 +16,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Table(name="profile")
  * @ORM\Entity(repositoryClass="ProfileRepository")
  */
-class Profile
+class Profile extends OAuthUser
 {
     /**
      * @var string
@@ -24,7 +25,7 @@ class Profile
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="NONE")
      */
-    private $username;
+    protected $username;
 
     /**
      * @Assert\NotBlank()
@@ -57,7 +58,7 @@ class Profile
      * @ORM\ManyToMany(targetEntity="Role", inversedBy="profiles")
      * @var Collection
      */
-    private $roles;
+    protected $roles;
 
     /**
      * @ORM\Column(type="string", length=255, nullable=TRUE)
@@ -158,11 +159,11 @@ class Profile
     }
 
     /**
-     * @return Collection
+     * @return array
      */
     public function getRoles()
     {
-        return $this->roles;
+        return $this->roles->toArray();
     }
 
     /**
@@ -219,6 +220,11 @@ class Profile
         $this->settlementHash = $settlementHash;
     }
 
-
+    /**
+     * @return Profile
+     */
+    public function getProfile() {
+        return $this;
+    }
 
 }

--- a/src/Mealz/UserBundle/Provider/OAuthUserProvider.php
+++ b/src/Mealz/UserBundle/Provider/OAuthUserProvider.php
@@ -10,18 +10,19 @@
 namespace Mealz\UserBundle\Provider;
 
 use \HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
+use \HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUserProvider as HWIBundleOAuthUserProvider;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;
 use Mealz\UserBundle\User\OAuthUser;
 use Mealz\UserBundle\Entity\Profile;
 use \Doctrine\Bundle\DoctrineBundle\Registry;
+use \Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * OAuthUserProvider.
  */
-class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProviderInterface
+class OAuthUserProvider extends HWIBundleOAuthUserProvider
 {
     /**
      * @var DoctrineRegistry
@@ -54,9 +55,11 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
      */
     public function loadUserByUsername($username)
     {
-        return new OAuthUser($username);
+        return $this->doctrineRegistry->getManager()->find(
+            'MealzUserBundle:Profile',
+            $username
+        );
     }
-
 
     /**
      * Loads an user by identifier or create it.
@@ -75,10 +78,10 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
         $userRoles = $this->fetchUserRoles($userInformation['roles']);
 
         // When non of the roles fetched - access is denied
-        if (count($userRoles) === 0) {
+        if ($userRoles->isEmpty() === true) {
             return false;
         }
-
+        
         // Check if all informations are given
         if (empty($username) === true ||
             gettype($userInformation) !== 'array' ||
@@ -88,22 +91,17 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
             return false;
         }
 
-        $profile = $this->doctrineRegistry->getManager()->find(
-            'MealzUserBundle:Profile',
-            $username
-        );
+        $user = $this->loadUserByUsername($username);
 
         // When Userprofile is null, create User
-        if ($profile === null) {
-            $profile = $this->createProfile(
+        if ($user === null) {
+            $user = $this->createProfile(
                 $username,
                 $this->extractGivenName($userInformation['given_name']),
                 $userInformation['family_name']
             );
         }
 
-        $user = new OAuthUser($username);
-        $user->setProfile($profile);
         $user->setRoles($userRoles);
 
         if ($user instanceof Login) {
@@ -139,7 +137,7 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
      */
     public function supportsClass($class)
     {
-        return $class === 'Mealz\\UserBundle\\User\\OAuthUser';
+        return $class === 'Mealz\\UserBundle\\Entity\\Profile';
     }
 
     /**
@@ -172,13 +170,13 @@ class OAuthUserProvider implements UserProviderInterface, OAuthAwareUserProvider
      * @return array
      */
     protected function fetchUserRoles($keycloakUserRoles) {
-        $fetchedRoles = [];
+        $fetchedRoles = new ArrayCollection();
 
         // Map Keycloak Roles to Meals Roles
         foreach ($this->roleMapping as $keycloakRoleName => $mealsRole) {
             // if the Keycloak User has Roles with mapped Roles in meals. Map it.
             if (array_search($keycloakRoleName, $keycloakUserRoles) !== false) {
-                array_push($fetchedRoles, $mealsRole);
+                $fetchedRoles->add($mealsRole);
             }
         }
 

--- a/src/Mealz/UserBundle/Tests/Service/OAuthProviderTest.php
+++ b/src/Mealz/UserBundle/Tests/Service/OAuthProviderTest.php
@@ -46,7 +46,7 @@ class OAuthProviderTest extends AbstractControllerTestCase
 
         // check if valid oAuth User comes in return
         $response = $oAuthProvider->loadUserByIdOrCreate($username, $newUserInformation);
-        $this->assertInstanceOf(OAuthUser::class, $response);
+        $this->assertInstanceOf(Profile::class, $response);
 
         // check if new valid Profile is written in Database
         $newCreatedProfile = $this->getDoctrine()->getManager()->find(
@@ -77,7 +77,7 @@ class OAuthProviderTest extends AbstractControllerTestCase
 
         // check if Response is a valid oAuth User
         $response = $oAuthProvider->loadUserByIdOrCreate($username, $validUserInformation);
-        $this->assertInstanceOf(OAuthUser::class, $response);
+        $this->assertInstanceOf(Profile::class, $response);
 
         // check if new valid Profile is written in Database
         $newCreatedProfile = $this->getDoctrine()->getManager()->find(
@@ -111,7 +111,7 @@ class OAuthProviderTest extends AbstractControllerTestCase
 
         // check if valid oAuth User comes in return
         $response = $oAuthProvider->loadUserByIdOrCreate($username, $newUserInformation);
-        $this->assertInstanceOf(OAuthUser::class, $response);
+        $this->assertInstanceOf(Profile::class, $response);
 
         // check if new valid Profile is written in Database
         $newCreatedProfile = $this->getDoctrine()->getManager()->find(


### PR DESCRIPTION
When a kochomi took some time to fill out the menu for next week and exceeded the keycloak token lifetime the save request ends in a new login request to keycloak. A new session was generated and the request wasn't executed.

The profile object will be used now and the refreshing of the token is fixed