### PR TITLE
Bug/empty menu participations

### DIFF
--- a/src/Resources/src/components/menuParticipants/MenuTableHead.vue
+++ b/src/Resources/src/components/menuParticipants/MenuTableHead.vue
@@ -6,14 +6,18 @@
       >
         {{ dateRangeStr }}
       </th>
-      <th
+      <template
         v-for="menuDayId in Object.keys(menuParticipationsState.days)"
         :key="menuDayId"
-        :colspan="getColspanFromMeals(menuDayId)"
-        class="sticky z-30 border-b-2 border-r-2 border-solid border-gray-200 bg-[#f4f7f9] p-2 text-center"
       >
-        {{ new Date(getDayByWeekIdAndDayId(weekId, menuDayId).dateTime.date).toLocaleDateString(locale, { weekday: 'long' }) }}
-      </th>
+        <th
+          v-if="Object.keys(getDayByWeekIdAndDayId(weekId, menuDayId).meals).length > 0"
+          :colspan="getColspanFromMeals(menuDayId)"
+          class="sticky z-30 border-b-2 border-r-2 border-solid border-gray-200 bg-[#f4f7f9] p-2 text-center"
+        >
+          {{ new Date(getDayByWeekIdAndDayId(weekId, menuDayId).dateTime.date).toLocaleDateString(locale, { weekday: 'long' }) }}
+        </th>
+      </template>
     </tr>
     <MenuTableRow
       :week-id="weekId"

--- a/src/Resources/src/components/menuParticipants/MenuTableRow.vue
+++ b/src/Resources/src/components/menuParticipants/MenuTableRow.vue
@@ -8,6 +8,7 @@
       :key="`${menuIndex}-${menuDayId}`"
     >
       <slot
+        v-if="Object.keys(getDayByWeekIdAndDayId(weekId, menuDayId).meals).length > 0"
         name="dayMeals"
         v-bind="{ dayId: menuDayId, meals: getArrayFromDict(getDayByWeekIdAndDayId(weekId, menuDayId).meals) }"
       />
@@ -28,6 +29,7 @@ const { menuParticipationsState } = useParticipations(props.weekId);
 const { getDayByWeekIdAndDayId } = useWeeks();
 
 function getArrayFromDict(dict: Dictionary<SimpleMeal[]>) {
-  return Object.values(dict).reduce((outputArr, mealArr) => [...outputArr, ...mealArr]);
+  const meals = Object.values(dict).reduce((outputArr, mealArr) => [...outputArr, ...mealArr], []);
+  return meals;
 }
 </script>

--- a/tests/e2e/cypress/e2e/MenuCreationRoundtrip.cy.ts
+++ b/tests/e2e/cypress/e2e/MenuCreationRoundtrip.cy.ts
@@ -28,8 +28,8 @@ describe('Test Creating a Menu', () => {
         // Hide Symphony's toolbar
         cy.get('a[class="hide-button"]').click();
 
-        // Go to 5th week (it should not have been created yet because of db reset)
-        cy.get('h4').eq(5).contains('Woche').click();
+        // Go to 7th week (it should not have been created yet because of db reset)
+        cy.get('h4').eq(6).contains('Woche').click();
 
         cy.wait(['@getDishesCount', '@getCategories', '@getDishes']);
 
@@ -348,8 +348,8 @@ describe('Test Creating a Menu', () => {
         // Hide Symphony's toolbar
         cy.get('a[class="hide-button"]').click();
 
-        // Go to 5th week (it should not have been created yet because of db reset)
-        cy.get('h4').eq(5).contains('Woche').click();
+        // Go to 7th week (it should not have been created yet because of db reset)
+        cy.get('h4').eq(6).contains('Woche').click();
 
         // change input
         cy.get('input')
@@ -370,7 +370,7 @@ describe('Test Creating a Menu', () => {
         cy.contains('div', 'Abbrechen').click();
 
         cy.get('h4')
-            .eq(5)
+            .eq(6)
             .contains('Woche')
             .parent()
             .find('div')


### PR DESCRIPTION
Fixed a bug that prevented the rendering of the MenuParticipationsTable if there were days without any meals. Also fixed a bug in the cypress test that prevented a week to be created on Fridays (on Friday the 6th week will be generated in the testdata).