### PR TITLE
Bugfix/#261162 offer lock meal

### DIFF
--- a/src/Resources/src/api/deleteCancelOffer.ts
+++ b/src/Resources/src/api/deleteCancelOffer.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 
 export async function useCancelOffer(data: string) {
     const { request, response, error } = useApi(
-        'POST',
+        'DELETE',
         'api/meal/offer',
         'application/json',
         data,

--- a/src/Resources/src/components/menu/MenuDay.vue
+++ b/src/Resources/src/components/menu/MenuDay.vue
@@ -100,7 +100,7 @@ watch(
     selectedDishes.value.meals[mealKeys.value[0]] = dishSlugs.map(dishSlug => {
       return {
         dishSlug: dishSlug,
-        mealId: mealIds.length > 0 ? mealIds.pop() : null,
+        mealId: mealIds.length > 0 ? mealIds.shift() : null,
         participationLimit: getParticipationLimitFromModel(dishSlug, mealKeys.value[0])
       };
     });
@@ -117,7 +117,7 @@ watch(
     selectedDishes.value.meals[mealKeys.value[1]] = dishSlugs.map(dishSlug => {
       return {
         dishSlug: dishSlug,
-        mealId: mealIds.length > 0 ? mealIds.pop() : null,
+        mealId: mealIds.length > 0 ? mealIds.shift() : null,
         participationLimit: getParticipationLimitFromModel(dishSlug, mealKeys.value[1])
       };
     });

--- a/src/Resources/src/components/menu/MenuLockDatePicker.vue
+++ b/src/Resources/src/components/menu/MenuLockDatePicker.vue
@@ -23,13 +23,14 @@
           <span class="w-full self-center truncate text-left text-xs font-medium text-[#173D7A]">
             {{ t('menu.lockDate') }}
           </span>
-          <input
-            :value="getLockDateAsStrRepr(new Date(lockDate.date))"
-            type="datetime-local"
-            class="w-full rounded-full border-2 border-solid border-[#CAD6E1] px-4 py-2 text-center text-[14px] text-[#9CA3AF]"
-            data-cy="meal-lockdate-input"
-            @change="event => lockDate.date = convertDateReprToLockDayFormat((event.target as HTMLInputElement).value)"
-          >
+          <VueDatePicker
+            v-model="date"
+            :enable-time-picker="true"
+            :time-picker-inline="true"
+            :clearable="false"
+            :format="locale.includes('de') ? 'dd.MM.yyyy HH:mm' : 'MM/dd/yyyy HH:mm'"
+            auto-apply
+          />
         </label>
       </div>
     </template>
@@ -42,18 +43,31 @@ import { CalendarIcon } from '@heroicons/vue/solid';
 import { useI18n } from 'vue-i18n';
 import { DateTime } from '@/api/getDashboardData';
 import { XCircleIcon } from '@heroicons/vue/solid';
+import VueDatePicker from '@vuepic/vue-datepicker';
+import { computed } from 'vue';
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   lockDate: DateTime
 }>();
 
+const date = computed({
+  get() {
+    return props.lockDate.date
+  },
+  set(value: Date | string) {
+    if(typeof(value) !== 'string') {
+      props.lockDate.date = convertDateReprToLockDayFormat(getLockDateAsStrRepr(value))
+    }
+  }
+})
+
 // output format: 2023-07-19T12:00
 function getLockDateAsStrRepr(date: Date) {
-  return new Date(date.setTime(date.getTime() + (2*60*60*1000)))
-    .toISOString()
-    .substring(0, 16);
+  const timezoneMillisOffset = date.getTimezoneOffset() * 60 * 1000;
+  date.setTime(date.getTime() - timezoneMillisOffset);
+  return date.toISOString().substring(0, 16);
 }
 
 // output format: 2023-07-13 16:00:00.000000

--- a/tests/e2e/cypress/e2e/Menu.cy.ts
+++ b/tests/e2e/cypress/e2e/Menu.cy.ts
@@ -90,9 +90,11 @@ describe('Test Weeks View', () => {
             .find('button')
             .last()
             .click()
-        cy.get('[data-cy="meal-lockdate-input"]')
-            .clear()
-            .type('2023-07-08T12:00')
+        cy.get('[aria-label="Datepicker input"]')
+            .click()
+        cy.get('div[class^="dp__cell_inner"]')
+            .contains(new RegExp(/^7$/))
+            .click()
         cy.get('span').contains('Sperren').parent().find('svg').click();
         cy.get('h2').should('contain', 'Woche bearbeiten #28 (10.07. - 14.07.)').click();
 

--- a/tests/e2e/cypress/fixtures/menuPut.json
+++ b/tests/e2e/cypress/fixtures/menuPut.json
@@ -26,7 +26,7 @@
                 "timezone": "Europe/Berlin"
             },
             "lockDate": {
-                "date": "2023-07-08T12:00:00.000000",
+                "date": "2023-07-07T16:00:00.000000",
                 "timezone_type": 3,
                 "timezone": "Europe/Berlin"
             }
@@ -66,12 +66,12 @@
                 "15": [
                     {
                         "dishSlug": "innards-v1",
-                        "mealId": 813,
+                        "mealId": 812,
                         "participationLimit": 0
                     },
                     {
                         "dishSlug": "innards-v2",
-                        "mealId": 812,
+                        "mealId": 813,
                         "participationLimit": 0
                     }
                 ],


### PR DESCRIPTION
- updated the MenuLockDatePicker component to use the VueDatePicker as an input
- fixed a bug that prevented offered meals to be reclaimed
- fixed a bug that made the date input behave different (wrong except for timezone 0 in summertime) for different timezones
- fixed a bug that assigned dish variations the wrong id on initially loading a menu that has dish variations selected